### PR TITLE
Update eslint-config-standard and peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,14 +14,14 @@
   },
   "homepage": "https://github.com/mostjs/eslint-config-most#readme",
   "dependencies": {
-    "eslint-config-standard": "^5.1.0",
+    "eslint-config-standard": "^5.3.5",
     "eslint-plugin-promise": "^2.0.0",
     "eslint-plugin-standard": "^2.0.0"
   },
   "peerDependencies": {
-    "eslint-config-standard": "^5.1.0",
-    "eslint-plugin-promise": "^1.0.8",
-    "eslint-plugin-standard": "^1.3.2"
+    "eslint-config-standard": "^5.3.5",
+    "eslint-plugin-promise": "^2.0.0",
+    "eslint-plugin-standard": "^2.0.0"
   },
   "scripts": {
     "postpublish": "greenkeeper-postpublish"


### PR DESCRIPTION
Updating to latest across the board.

Any thoughts on semver implications?  Two of the deps had major version bumps.  It isn't entirely clear from reading https://github.com/mojombo/semver/issues/148.
